### PR TITLE
feat: add --timecodes flag to cut video at specified timecode boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/shaztechio/video-cutter/actions/workflows/ci.yml/badge.svg)](https://github.com/shaztechio/video-cutter/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/@shaztech/video-cutter.svg)](https://www.npmjs.com/package/@shaztech/video-cutter)
 
-A CLI tool to cut a video file into segments using ffmpeg — by equal count, fixed duration, or automatic scene change detection.
+A CLI tool to cut a video file into segments using ffmpeg — by equal count, fixed duration, specific timecodes, or automatic scene change detection.
 
 ## Prerequisites
 
@@ -39,6 +39,8 @@ Options:
   -d, --duration <seconds>       duration of each segment in seconds
   --scene-detect [threshold]     cut at scene change boundaries (threshold
                                  0–100, default: 10)
+  -t, --timecodes <timecodes>    cut at specified timecodes (CSV, see formats
+                                 below)
   -o, --output <path>            output directory for segments (default:
                                  ./output/YYYY-MM-DD_HH-MM-SS/)
   --verify                       verify that each segment matches its intended
@@ -67,6 +69,40 @@ video-cutter -i my_video.mp4 -d 30
 This will create files named `seg_01_00-00-00.mp4`, `seg_02_00-00-30.mp4`, etc. in the default timestamped output directory.
 
 **Note:** When using the `-d` flag without `--re-encode`, segment durations may not be exactly as specified due to keyframe alignment when stream copying. For exact durations, use the `--re-encode` flag.
+
+### Cut a video at specific timecodes:
+
+```bash
+video-cutter -i my_video.mp4 -t "00:00:10,00:00:30,00:01:00"
+```
+
+This cuts the video at 10s, 30s, and 1 minute, producing 4 segments that cover the full video:
+
+```
+tc_001_00-00-00.000.mp4   # 0s → 10s
+tc_002_00-00-10.000.mp4   # 10s → 30s
+tc_003_00-00-30.000.mp4   # 30s → 1m
+tc_004_00-01-00.000.mp4   # 1m → end
+```
+
+Filenames include a sequence number and the segment's start timecode, so they sort correctly in any file browser.
+
+#### Supported timecode formats
+
+All formats can be mixed freely in a single `-t` value:
+
+| Format | Example | Description |
+|--------|---------|-------------|
+| `HH:MM:SS` | `00:01:30` | Hours, minutes, seconds |
+| `HH:MM:SS.nnn` | `00:01:30.500` | With milliseconds |
+| `Ns` | `90s` | Seconds only |
+| `N.Ns` | `90.5s` | Seconds with decimal |
+| `NhNmNs` | `1h30m0s` | Hours, minutes, seconds with suffixes |
+| `NhNmN.Ns` | `0h1m30.5s` | With decimal seconds |
+
+The `h` and `m` components are optional — `5m30s` and `90s` are both valid.
+
+**Note:** Timecodes must be in ascending order and within the video's duration, or the command will exit with an error indicating which position is invalid.
 
 ### Cut a video at scene changes (automatic detection):
 
@@ -107,10 +143,11 @@ video-cutter -i my_video.mp4 -n 10 -o ./my_segments/
 - When creating segments shorter than 30 seconds, you'll be prompted for confirmation
 - Segment numbers are zero-padded to 3 digits (001, 002, etc.) for count-based segments
 - Time-based segments are named with both sequence number and start time (e.g., seg_01_00-00-00.mp4)
-- The `--segments`, `--duration`, and `--scene-detect` options are mutually exclusive
+- The `--segments`, `--duration`, `--scene-detect`, and `--timecodes` options are mutually exclusive
 - By default, the tool uses stream copying for fast segment creation, which may result in slight duration inaccuracies due to keyframe alignment
 - Use the `--re-encode` flag to re-encode segments for precise duration control (slower but exact)
 - Use the `--verify` flag to check that each segment matches its intended duration after creation
 - When using both `--re-encode` and `--verify`, segments will have exact durations as specified
 - Scene-detect segments are named `scene_001.mp4`, `scene_002.mp4`, etc.
+- Timecode segments are named `tc_NNN_HH-MM-SS.mmm.mp4` using the sequence number and start time of each segment
 - The `--scene-detect` threshold is a value from 0–100 representing the minimum frame difference score to trigger a cut; the recommended range is 8–14 (default: 10)

--- a/index.js
+++ b/index.js
@@ -110,6 +110,14 @@ async function processVideo (options) {
         process.exit(1)
       }
 
+      // Validate all timecodes are > 0
+      for (let i = 0; i < parsed.length; i++) {
+        if (parsed[i] <= 0) {
+          error(`Timecode at position ${i + 1} must be greater than 0`)
+          process.exit(1)
+        }
+      }
+
       // Validate ascending order
       for (let i = 1; i < parsed.length; i++) {
         if (parsed[i] <= parsed[i - 1]) {

--- a/index.js
+++ b/index.js
@@ -25,7 +25,9 @@ import {
   createCountSegments,
   createTimeSegments,
   detectSceneChanges,
-  createSceneSegments
+  createSceneSegments,
+  parseTimecodes,
+  createTimecodeSegments
 } from './src/core.js'
 
 // Colored console output helpers
@@ -96,6 +98,41 @@ async function processVideo (options) {
     }
 
     console.log(`Video duration: ${duration} seconds`)
+
+    const timecodes = options.timecodes ?? null
+
+    if (timecodes !== null) {
+      let parsed
+      try {
+        parsed = parseTimecodes(timecodes)
+      } catch (err) {
+        error(err.message)
+        process.exit(1)
+      }
+
+      // Validate ascending order
+      for (let i = 1; i < parsed.length; i++) {
+        if (parsed[i] <= parsed[i - 1]) {
+          error(`Timecode at position ${i + 1} is not in ascending order`)
+          process.exit(1)
+        }
+      }
+
+      // Validate within video duration
+      for (let i = 0; i < parsed.length; i++) {
+        if (parsed[i] >= duration) {
+          error(`Timecode at position ${i + 1} exceeds video duration of ${duration.toFixed(2)} seconds`)
+          process.exit(1)
+        }
+      }
+
+      const boundaries = [0, ...parsed, duration]
+      console.log(`${boundaries.length - 1} segment(s) will be created.`)
+      if (!reEncode) {
+        console.warn('Using stream copy mode. Durations may vary slightly. Use --re-encode for exact cuts.')
+      }
+      return createTimecodeSegments(inputFile, outputPath, boundaries, verifySegments, reEncode)
+    }
 
     const sceneDetect = options.sceneDetect ?? null
     const threshold = sceneDetect === true ? 10 : (sceneDetect ? parseInt(sceneDetect) : null)
@@ -206,6 +243,12 @@ function setupCli () {
       new Option('--scene-detect [threshold]', 'cut at scene change boundaries (threshold 0–100, default: 10)')
         .conflicts('segments')
         .conflicts('duration')
+    )
+    .addOption(
+      new Option('-t, --timecodes <timecodes>', 'cut at specified timecodes (CSV: HH:MM:SS[.nnnn],...)')
+        .conflicts('segments')
+        .conflicts('duration')
+        .conflicts('scene-detect')
     )
     .option('-o, --output <path>', 'output directory for segments (default: ./output/YYYY-MM-DD_HH-MM-SS/)')
     .option('--verify', 'verify that each segment matches its intended duration')

--- a/index.js
+++ b/index.js
@@ -248,7 +248,7 @@ function setupCli () {
       new Option('-t, --timecodes <timecodes>', 'cut at specified timecodes (CSV: HH:MM:SS[.nnnn],...)')
         .conflicts('segments')
         .conflicts('duration')
-        .conflicts('scene-detect')
+        .conflicts('sceneDetect')
     )
     .option('-o, --output <path>', 'output directory for segments (default: ./output/YYYY-MM-DD_HH-MM-SS/)')
     .option('--verify', 'verify that each segment matches its intended duration')

--- a/src/core.js
+++ b/src/core.js
@@ -366,6 +366,23 @@ function parseTimecodes (timecodeString) {
 }
 
 /**
+ * Format a time in seconds as HH-MM-SS.mmm for use in filenames.
+ * Uses integer millisecond arithmetic to correctly handle rounding carry.
+ *
+ * @param {number} seconds - Time in seconds (may be fractional)
+ * @returns {string} Formatted time string, e.g. "01-02-03.456"
+ */
+function formatTimecodeFilenameTime (seconds) {
+  const totalMs = Math.round(seconds * 1000)
+  const hours = Math.floor(totalMs / 3600000)
+  const minutes = Math.floor((totalMs % 3600000) / 60000)
+  const wholeSeconds = Math.floor((totalMs % 60000) / 1000)
+  const millis = totalMs % 1000
+  const pad = (n) => String(n).padStart(2, '0')
+  return `${pad(hours)}-${pad(minutes)}-${pad(wholeSeconds)}.${String(millis).padStart(3, '0')}`
+}
+
+/**
  * Create video segments at specified timecode boundaries
  *
  * @param {string} inputFile - Path to the input video file
@@ -383,14 +400,8 @@ async function createTimecodeSegments (inputFile, outputDir, boundaries, verifyS
     const startTime = boundaries[i]
     const endTime = boundaries[i + 1]
 
-    const hours = Math.floor(startTime / 3600)
-    const minutes = Math.floor((startTime % 3600) / 60)
-    const secs = startTime % 60
-    const pad = (n) => String(n).padStart(2, '0')
-    const millisStr = secs.toFixed(3).split('.')[1]
-    const timeStr = `${pad(hours)}-${pad(minutes)}-${pad(Math.floor(secs))}.${millisStr}`
     const seqStr = String(i + 1).padStart(3, '0')
-    const segmentFile = path.join(outputDir, `tc_${seqStr}_${timeStr}.mp4`)
+    const segmentFile = path.join(outputDir, `tc_${seqStr}_${formatTimecodeFilenameTime(startTime)}.mp4`)
 
     promises.push(createSegment(inputFile, startTime, endTime, segmentFile, reEncode))
   }
@@ -406,14 +417,8 @@ async function createTimecodeSegments (inputFile, outputDir, boundaries, verifyS
           const endTime = boundaries[i + 1]
           const expectedDuration = endTime - startTime
 
-          const hours = Math.floor(startTime / 3600)
-          const minutes = Math.floor((startTime % 3600) / 60)
-          const secs = startTime % 60
-          const pad = (n) => String(n).padStart(2, '0')
-          const millisStr = secs.toFixed(3).split('.')[1]
-          const timeStr = `${pad(hours)}-${pad(minutes)}-${pad(Math.floor(secs))}.${millisStr}`
           const seqStr = String(i + 1).padStart(3, '0')
-          const segmentFile = path.join(outputDir, `tc_${seqStr}_${timeStr}.mp4`)
+          const segmentFile = path.join(outputDir, `tc_${seqStr}_${formatTimecodeFilenameTime(startTime)}.mp4`)
 
           const actualDuration = await getVideoDuration(segmentFile)
           const difference = Math.abs(actualDuration - expectedDuration)

--- a/src/core.js
+++ b/src/core.js
@@ -358,7 +358,9 @@ function parseTimecodes (timecodeString) {
       const h = parseInt(hmsMatch[1] ?? '0')
       const m = parseInt(hmsMatch[2] ?? '0')
       const s = parseFloat(hmsMatch[3])
-      return h * 3600 + m * 60 + s
+      const seconds = h * 3600 + m * 60 + s
+      if (!Number.isFinite(seconds)) throw new Error(`Invalid timecode at position ${pos}: "${trimmed}"`)
+      return seconds
     }
 
     throw new Error(`Invalid timecode at position ${pos}: "${trimmed}"`)

--- a/src/core.js
+++ b/src/core.js
@@ -330,11 +330,114 @@ async function createSceneSegments (inputFile, outputDir, boundaries, verifySegm
     })
 }
 
+/**
+ * Parse a CSV string of HH:MM:SS[.nnnn] timecodes into an array of seconds
+ *
+ * @param {string} timecodeString - Comma-separated timecodes e.g. "00:00:10.000,00:00:30.000"
+ * @returns {number[]} - Array of timestamps in seconds
+ */
+function parseTimecodes (timecodeString) {
+  return timecodeString.split(',').map((tc, i) => {
+    const trimmed = tc.trim()
+    const pos = i + 1
+
+    // Format: HH:MM:SS[.nnn]
+    if (trimmed.includes(':')) {
+      const parts = trimmed.split(':')
+      if (parts.length !== 3) throw new Error(`Invalid timecode at position ${pos}: "${trimmed}"`)
+      const [h, m, s] = parts
+      const seconds = parseInt(h) * 3600 + parseInt(m) * 60 + parseFloat(s)
+      if (isNaN(seconds)) throw new Error(`Invalid timecode at position ${pos}: "${trimmed}"`)
+      return seconds
+    }
+
+    // Format: [Nh][Nm]N[.N]s — covers "10s", "10.25s", "0h0m10s", "1h30m15.2s"
+    const hmsMatch = trimmed.match(/^(?:(\d+)h)?(?:(\d+)m)?(\d+(?:\.\d+)?)s$/)
+    if (hmsMatch) {
+      const h = parseInt(hmsMatch[1] ?? '0')
+      const m = parseInt(hmsMatch[2] ?? '0')
+      const s = parseFloat(hmsMatch[3])
+      return h * 3600 + m * 60 + s
+    }
+
+    throw new Error(`Invalid timecode at position ${pos}: "${trimmed}"`)
+  })
+}
+
+/**
+ * Create video segments at specified timecode boundaries
+ *
+ * @param {string} inputFile - Path to the input video file
+ * @param {string} outputDir - Directory to save the segments
+ * @param {number[]} boundaries - Array of timestamps including 0 at start and total duration at end
+ * @param {boolean} verifySegments - Whether to verify segment durations
+ * @param {boolean} reEncode - Whether to re-encode for exact duration
+ * @returns {Promise<void>}
+ */
+async function createTimecodeSegments (inputFile, outputDir, boundaries, verifySegments = false, reEncode = false) {
+  const segmentCount = boundaries.length - 1
+  const promises = []
+
+  for (let i = 0; i < segmentCount; i++) {
+    const startTime = boundaries[i]
+    const endTime = boundaries[i + 1]
+
+    const hours = Math.floor(startTime / 3600)
+    const minutes = Math.floor((startTime % 3600) / 60)
+    const secs = startTime % 60
+    const pad = (n) => String(n).padStart(2, '0')
+    const millisStr = secs.toFixed(3).split('.')[1]
+    const timeStr = `${pad(hours)}-${pad(minutes)}-${pad(Math.floor(secs))}.${millisStr}`
+    const seqStr = String(i + 1).padStart(3, '0')
+    const segmentFile = path.join(outputDir, `tc_${seqStr}_${timeStr}.mp4`)
+
+    promises.push(createSegment(inputFile, startTime, endTime, segmentFile, reEncode))
+  }
+
+  return Promise.all(promises)
+    .then(async () => {
+      console.log('All segments created successfully!')
+
+      if (verifySegments) {
+        console.log('Verifying segment durations...')
+        for (let i = 0; i < segmentCount; i++) {
+          const startTime = boundaries[i]
+          const endTime = boundaries[i + 1]
+          const expectedDuration = endTime - startTime
+
+          const hours = Math.floor(startTime / 3600)
+          const minutes = Math.floor((startTime % 3600) / 60)
+          const secs = startTime % 60
+          const pad = (n) => String(n).padStart(2, '0')
+          const millisStr = secs.toFixed(3).split('.')[1]
+          const timeStr = `${pad(hours)}-${pad(minutes)}-${pad(Math.floor(secs))}.${millisStr}`
+          const seqStr = String(i + 1).padStart(3, '0')
+          const segmentFile = path.join(outputDir, `tc_${seqStr}_${timeStr}.mp4`)
+
+          const actualDuration = await getVideoDuration(segmentFile)
+          const difference = Math.abs(actualDuration - expectedDuration)
+          const tolerance = reEncode ? 0.1 : 1.0
+          if (difference > tolerance) {
+            console.warn(`Warning: Segment ${segmentFile} duration is ${actualDuration.toFixed(2)} seconds, expected ${expectedDuration.toFixed(2)} seconds`)
+          } else {
+            console.log(colors.green(`Verified: ${segmentFile} duration is correct`))
+          }
+        }
+      }
+    })
+    .catch(err => {
+      console.error('Error creating segments:', err)
+      process.exit(1)
+    })
+}
+
 export {
   getVideoDuration,
   createSegment,
   createCountSegments,
   createTimeSegments,
   detectSceneChanges,
-  createSceneSegments
+  createSceneSegments,
+  parseTimecodes,
+  createTimecodeSegments
 }

--- a/src/core.js
+++ b/src/core.js
@@ -331,9 +331,10 @@ async function createSceneSegments (inputFile, outputDir, boundaries, verifySegm
 }
 
 /**
- * Parse a CSV string of HH:MM:SS[.nnnn] timecodes into an array of seconds
+ * Parse a CSV string of timecodes into an array of seconds.
+ * Supported formats are HH:MM:SS[.nnnn], Ns, N.Ns, and [Nh][Nm]N[.N]s.
  *
- * @param {string} timecodeString - Comma-separated timecodes e.g. "00:00:10.000,00:00:30.000"
+ * @param {string} timecodeString - Comma-separated timecodes, e.g. "00:00:10.000,00:00:30.000", "10s,10.25s", or "0h0m10s,1h30m15.2s"
  * @returns {number[]} - Array of timestamps in seconds
  */
 function parseTimecodes (timecodeString) {
@@ -343,11 +344,11 @@ function parseTimecodes (timecodeString) {
 
     // Format: HH:MM:SS[.nnn]
     if (trimmed.includes(':')) {
-      const parts = trimmed.split(':')
-      if (parts.length !== 3) throw new Error(`Invalid timecode at position ${pos}: "${trimmed}"`)
-      const [h, m, s] = parts
-      const seconds = parseInt(h) * 3600 + parseInt(m) * 60 + parseFloat(s)
-      if (isNaN(seconds)) throw new Error(`Invalid timecode at position ${pos}: "${trimmed}"`)
+      const colonMatch = trimmed.match(/^(\d+):(\d+):(\d+(?:\.\d+)?)$/)
+      if (!colonMatch) throw new Error(`Invalid timecode at position ${pos}: "${trimmed}"`)
+      const [, h, m, s] = colonMatch
+      const seconds = Number.parseInt(h, 10) * 3600 + Number.parseInt(m, 10) * 60 + Number.parseFloat(s)
+      if (!Number.isFinite(seconds)) throw new Error(`Invalid timecode at position ${pos}: "${trimmed}"`)
       return seconds
     }
 

--- a/tests/core.spec.js
+++ b/tests/core.spec.js
@@ -16,7 +16,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { EventEmitter } from 'events'
 
 import { spawn } from 'child_process'
-import { getVideoDuration, createSegment, createCountSegments, createTimeSegments, detectSceneChanges, createSceneSegments } from '../src/core.js'
+import { getVideoDuration, createSegment, createCountSegments, createTimeSegments, detectSceneChanges, createSceneSegments, parseTimecodes, createTimecodeSegments } from '../src/core.js'
 
 vi.mock('child_process', () => ({
   spawn: vi.fn()
@@ -329,6 +329,145 @@ describe('createSceneSegments', () => {
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit') })
     vi.mocked(spawn).mockReturnValueOnce(createMockProcess({ exitCode: 1 }))
     await expect(createSceneSegments('video.mp4', '/output', [0, 5.2, 30])).rejects.toThrow('exit')
+    expect(exitSpy).toHaveBeenCalledWith(1)
+  })
+})
+
+describe('parseTimecodes', () => {
+  describe('HH:MM:SS format', () => {
+    it('parses a single timecode into seconds', () => {
+      expect(parseTimecodes('00:00:10.000')).toEqual([10])
+    })
+
+    it('parses multiple timecodes into seconds', () => {
+      expect(parseTimecodes('00:00:10.000,00:00:30.000,00:01:00.000')).toEqual([10, 30, 60])
+    })
+
+    it('handles sub-second precision', () => {
+      expect(parseTimecodes('00:00:10.500')).toEqual([10.5])
+    })
+
+    it('handles hours correctly', () => {
+      expect(parseTimecodes('01:00:00.000')).toEqual([3600])
+    })
+
+    it('omitting milliseconds works (HH:MM:SS)', () => {
+      expect(parseTimecodes('00:00:10,00:00:30')).toEqual([10, 30])
+    })
+
+    it('trims whitespace around timecodes', () => {
+      expect(parseTimecodes(' 00:00:10.000 , 00:00:30.000 ')).toEqual([10, 30])
+    })
+
+    it('throws on wrong number of colon-separated parts', () => {
+      expect(() => parseTimecodes('00:10.000')).toThrow('Invalid timecode at position 1')
+    })
+
+    it('throws on NaN result', () => {
+      expect(() => parseTimecodes('00:xx:10.000')).toThrow('Invalid timecode at position 1')
+    })
+  })
+
+  describe('Ns / N.Ns format', () => {
+    it('parses whole seconds', () => {
+      expect(parseTimecodes('10s,15s,25s')).toEqual([10, 15, 25])
+    })
+
+    it('parses decimal seconds', () => {
+      expect(parseTimecodes('10.25s,15.2s,25.1s')).toEqual([10.25, 15.2, 25.1])
+    })
+
+    it('trims whitespace', () => {
+      expect(parseTimecodes(' 10s , 20s ')).toEqual([10, 20])
+    })
+  })
+
+  describe('NhNmNs format', () => {
+    it('parses full h/m/s', () => {
+      expect(parseTimecodes('0h0m10s,0h0m30s')).toEqual([10, 30])
+    })
+
+    it('parses decimal seconds in hms format', () => {
+      expect(parseTimecodes('0h0m15.2s')).toEqual([15.2])
+    })
+
+    it('parses hours and minutes correctly', () => {
+      expect(parseTimecodes('1h30m0s')).toEqual([5400])
+    })
+
+    it('allows omitting h and m components', () => {
+      expect(parseTimecodes('10s')).toEqual([10])
+    })
+
+    it('allows omitting h component only', () => {
+      expect(parseTimecodes('5m30s')).toEqual([330])
+    })
+  })
+
+  describe('error cases', () => {
+    it('throws on completely invalid format', () => {
+      expect(() => parseTimecodes('badval')).toThrow('Invalid timecode at position 1')
+    })
+
+    it('includes position number in error for second invalid timecode', () => {
+      expect(() => parseTimecodes('10s,badval')).toThrow('Invalid timecode at position 2')
+    })
+  })
+})
+
+describe('createTimecodeSegments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  it('creates segments with tc_NNN_HH-MM-SS.mmm.mp4 filenames', async () => {
+    vi.mocked(spawn)
+      .mockReturnValueOnce(createMockProcess())
+      .mockReturnValueOnce(createMockProcess())
+    await expect(createTimecodeSegments('video.mp4', '/output', [0, 10, 30])).resolves.toBeUndefined()
+    expect(spawn).toHaveBeenCalledTimes(2)
+    expect(spawn).toHaveBeenCalledWith('ffmpeg', expect.arrayContaining([expect.stringContaining('tc_001_00-00-00.000.mp4')]))
+    expect(spawn).toHaveBeenCalledWith('ffmpeg', expect.arrayContaining([expect.stringContaining('tc_002_00-00-10.000.mp4')]))
+  })
+
+  it('passes reEncode=true through to spawn args', async () => {
+    vi.mocked(spawn).mockReturnValueOnce(createMockProcess())
+    await createTimecodeSegments('video.mp4', '/output', [0, 30], false, true)
+    expect(spawn).toHaveBeenCalledWith('ffmpeg', expect.arrayContaining(['-c:v', 'libx264']))
+  })
+
+  it('verifies durations when verifySegments=true', async () => {
+    vi.mocked(spawn)
+      .mockReturnValueOnce(createMockProcess())
+      .mockReturnValueOnce(createMockProcess({ stdoutData: '10.0\n' }))
+    await createTimecodeSegments('video.mp4', '/output', [0, 10], true)
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('Verified'))
+  })
+
+  it('warns on duration mismatch during verification', async () => {
+    vi.mocked(spawn)
+      .mockReturnValueOnce(createMockProcess())
+      .mockReturnValueOnce(createMockProcess({ stdoutData: '1.0\n' })) // expected 10s
+    await createTimecodeSegments('video.mp4', '/output', [0, 10], true)
+    expect(console.warn).toHaveBeenCalled()
+  })
+
+  it('uses 0.1s tolerance when re-encoding during verification', async () => {
+    vi.mocked(spawn)
+      .mockReturnValueOnce(createMockProcess())
+      .mockReturnValueOnce(createMockProcess({ stdoutData: '9.5\n' })) // 0.5s diff > 0.1s tolerance
+    await createTimecodeSegments('video.mp4', '/output', [0, 10], true, true)
+    expect(console.warn).toHaveBeenCalled()
+  })
+
+  it('calls process.exit(1) on segment creation failure', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit') })
+    vi.mocked(spawn).mockReturnValueOnce(createMockProcess({ exitCode: 1 }))
+    await expect(createTimecodeSegments('video.mp4', '/output', [0, 10, 30])).rejects.toThrow('exit')
     expect(exitSpy).toHaveBeenCalledWith(1)
   })
 })

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -291,6 +291,17 @@ describe('processVideo', () => {
       expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Invalid timecode at position 1'))
     })
 
+    it('exits with error when a timecode is zero or negative', async () => {
+      vi.spyOn(fs, 'existsSync').mockReturnValue(true)
+      vi.mocked(getVideoDuration).mockResolvedValue(120)
+      vi.mocked(parseTimecodes).mockReturnValue([0, 10])
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit') })
+
+      await expect(processVideo({ input: 'video.mp4', output: '/out', timecodes: '0s,10s' })).rejects.toThrow('exit')
+      expect(exitSpy).toHaveBeenCalledWith(1)
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('position 1'))
+    })
+
     it('exits with error when timecodes are not in ascending order', async () => {
       vi.spyOn(fs, 'existsSync').mockReturnValue(true)
       vi.mocked(getVideoDuration).mockResolvedValue(120)

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -16,8 +16,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 import fs from 'fs'
 import inquirer from 'inquirer'
-import { Command } from 'commander'
-import { getVideoDuration, createCountSegments, createTimeSegments, detectSceneChanges, createSceneSegments } from '../src/core.js'
+import { Command, Option } from 'commander'
+import { getVideoDuration, createCountSegments, createTimeSegments, detectSceneChanges, createSceneSegments, parseTimecodes, createTimecodeSegments } from '../src/core.js'
 import { processVideo, setupCli } from '../index.js'
 
 vi.mock('child_process', () => ({
@@ -30,7 +30,9 @@ vi.mock('../src/core.js', () => ({
   createCountSegments: vi.fn(),
   createTimeSegments: vi.fn(),
   detectSceneChanges: vi.fn(),
-  createSceneSegments: vi.fn()
+  createSceneSegments: vi.fn(),
+  parseTimecodes: vi.fn(),
+  createTimecodeSegments: vi.fn()
 }))
 
 vi.mock('commander', () => {
@@ -232,6 +234,86 @@ describe('processVideo', () => {
     })
   })
 
+  describe('timecode segmentation (--timecodes)', () => {
+    it('calls createTimecodeSegments with boundaries [0, ...parsed, duration]', async () => {
+      vi.spyOn(fs, 'existsSync').mockReturnValue(true)
+      vi.mocked(getVideoDuration).mockResolvedValue(120)
+      vi.mocked(parseTimecodes).mockReturnValue([10, 30, 60])
+      vi.mocked(createTimecodeSegments).mockResolvedValue()
+
+      await processVideo({ input: 'video.mp4', output: '/out', timecodes: '00:00:10.000,00:00:30.000,00:01:00.000' })
+
+      expect(parseTimecodes).toHaveBeenCalledWith('00:00:10.000,00:00:30.000,00:01:00.000')
+      expect(createTimecodeSegments).toHaveBeenCalledWith('video.mp4', '/out', [0, 10, 30, 60, 120], false, false)
+    })
+
+    it('passes verify and reEncode flags correctly', async () => {
+      vi.spyOn(fs, 'existsSync').mockReturnValue(true)
+      vi.mocked(getVideoDuration).mockResolvedValue(120)
+      vi.mocked(parseTimecodes).mockReturnValue([10, 30])
+      vi.mocked(createTimecodeSegments).mockResolvedValue()
+
+      await processVideo({ input: 'video.mp4', output: '/out', timecodes: '00:00:10.000,00:00:30.000', verify: true, reEncode: true })
+
+      expect(createTimecodeSegments).toHaveBeenCalledWith('video.mp4', '/out', [0, 10, 30, 120], true, true)
+    })
+
+    it('warns about stream copy mode when not re-encoding', async () => {
+      vi.spyOn(fs, 'existsSync').mockReturnValue(true)
+      vi.mocked(getVideoDuration).mockResolvedValue(120)
+      vi.mocked(parseTimecodes).mockReturnValue([10, 30])
+      vi.mocked(createTimecodeSegments).mockResolvedValue()
+
+      await processVideo({ input: 'video.mp4', output: '/out', timecodes: '00:00:10.000,00:00:30.000' })
+
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('stream copy mode'))
+    })
+
+    it('does not warn about stream copy when reEncode is true', async () => {
+      vi.spyOn(fs, 'existsSync').mockReturnValue(true)
+      vi.mocked(getVideoDuration).mockResolvedValue(120)
+      vi.mocked(parseTimecodes).mockReturnValue([10, 30])
+      vi.mocked(createTimecodeSegments).mockResolvedValue()
+
+      await processVideo({ input: 'video.mp4', output: '/out', timecodes: '00:00:10.000,00:00:30.000', reEncode: true })
+
+      expect(console.warn).not.toHaveBeenCalled()
+    })
+
+    it('exits with error when parseTimecodes throws (invalid format)', async () => {
+      vi.spyOn(fs, 'existsSync').mockReturnValue(true)
+      vi.mocked(getVideoDuration).mockResolvedValue(120)
+      vi.mocked(parseTimecodes).mockImplementation(() => { throw new Error('Invalid timecode at position 1: "badval"') })
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit') })
+
+      await expect(processVideo({ input: 'video.mp4', output: '/out', timecodes: 'badval' })).rejects.toThrow('exit')
+      expect(exitSpy).toHaveBeenCalledWith(1)
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Invalid timecode at position 1'))
+    })
+
+    it('exits with error when timecodes are not in ascending order', async () => {
+      vi.spyOn(fs, 'existsSync').mockReturnValue(true)
+      vi.mocked(getVideoDuration).mockResolvedValue(120)
+      vi.mocked(parseTimecodes).mockReturnValue([30, 10])
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit') })
+
+      await expect(processVideo({ input: 'video.mp4', output: '/out', timecodes: '00:00:30.000,00:00:10.000' })).rejects.toThrow('exit')
+      expect(exitSpy).toHaveBeenCalledWith(1)
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('position 2'))
+    })
+
+    it('exits with error when a timecode exceeds video duration', async () => {
+      vi.spyOn(fs, 'existsSync').mockReturnValue(true)
+      vi.mocked(getVideoDuration).mockResolvedValue(120)
+      vi.mocked(parseTimecodes).mockReturnValue([10, 200])
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit') })
+
+      await expect(processVideo({ input: 'video.mp4', output: '/out', timecodes: '00:00:10.000,00:03:20.000' })).rejects.toThrow('exit')
+      expect(exitSpy).toHaveBeenCalledWith(1)
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('position 2'))
+    })
+  })
+
   describe('scene-detect segmentation (--scene-detect)', () => {
     it('calls detectSceneChanges with threshold 10 when sceneDetect is true', async () => {
       vi.spyOn(fs, 'existsSync').mockReturnValue(true)
@@ -327,5 +409,13 @@ describe('setupCli', () => {
     expect(program.requiredOption).toHaveBeenCalledWith('-i, --input <path>', expect.any(String))
     expect(program.action).toHaveBeenCalledWith(processVideo)
     expect(program.parse).toHaveBeenCalled()
+  })
+
+  it('registers --timecodes option via addOption', () => {
+    setupCli()
+    expect(vi.mocked(Option)).toHaveBeenCalledWith(
+      expect.stringContaining('--timecodes'),
+      expect.any(String)
+    )
   })
 })

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -299,7 +299,7 @@ describe('processVideo', () => {
 
       await expect(processVideo({ input: 'video.mp4', output: '/out', timecodes: '0s,10s' })).rejects.toThrow('exit')
       expect(exitSpy).toHaveBeenCalledWith(1)
-      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('position 1'))
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('position 1 must be greater than 0'))
     })
 
     it('exits with error when timecodes are not in ascending order', async () => {


### PR DESCRIPTION
- [x] Analyze comments and identify issues to fix
- [x] Fix timestamp rounding carry in `createTimecodeSegments` filename formatting (src/core.js)
- [x] Fix `.conflicts('scene-detect')` → `.conflicts('sceneDetect')` in index.js
- [x] Add validation to reject timecodes ≤ 0 (index.js) — prevents zero-length first segment when `-t 0s` is used
- [x] Add test for `> 0` timecode validation with specific error message assertion
- [x] All 94 tests passing