### PR TITLE
feat: support HH:MM:SS:MS timecode format in --timecodes flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ All formats can be mixed freely in a single `-t` value:
 |--------|---------|-------------|
 | `HH:MM:SS` | `00:01:30` | Hours, minutes, seconds |
 | `HH:MM:SS.nnn` | `00:01:30.500` | With milliseconds |
+| `HH:MM:SS:MS` | `00:01:30:04` | MS field as fractional seconds scaled by digit count (`:4`→0.4 s, `:04`→0.04 s) |
 | `Ns` | `90s` | Seconds only |
 | `N.Ns` | `90.5s` | Seconds with decimal |
 | `NhNmNs` | `1h30m0s` | Hours, minutes, seconds with suffixes |

--- a/index.js
+++ b/index.js
@@ -253,7 +253,7 @@ function setupCli () {
         .conflicts('duration')
     )
     .addOption(
-      new Option('-t, --timecodes <timecodes>', 'cut at specified timecodes (CSV: HH:MM:SS[.nnnn] or HH:MM:SS:MS,...)')
+      new Option('-t, --timecodes <timecodes>', 'cut at specified timecodes (CSV: HH:MM:SS[.nnnn] or HH:MM:SS:MS where the final field is fractional seconds scaled by digit count, e.g. :4 = 0.4s, :04 = 0.04s, ...)')
         .conflicts('segments')
         .conflicts('duration')
         .conflicts('sceneDetect')

--- a/index.js
+++ b/index.js
@@ -253,7 +253,7 @@ function setupCli () {
         .conflicts('duration')
     )
     .addOption(
-      new Option('-t, --timecodes <timecodes>', 'cut at specified timecodes (CSV: HH:MM:SS[.nnnn] or HH:MM:SS:MS where the final field is fractional seconds scaled by digit count, e.g. :4 = 0.4s, :04 = 0.04s, ...)')
+      new Option('-t, --timecodes <timecodes>', 'cut at specified timecodes (CSV: HH:MM:SS[.nnnn] or HH:MM:SS:MS; MS scaled by digits, e.g. :4=0.4s, :04=0.04s)')
         .conflicts('segments')
         .conflicts('duration')
         .conflicts('sceneDetect')

--- a/index.js
+++ b/index.js
@@ -253,7 +253,7 @@ function setupCli () {
         .conflicts('duration')
     )
     .addOption(
-      new Option('-t, --timecodes <timecodes>', 'cut at specified timecodes (CSV: HH:MM:SS[.nnnn],...)')
+      new Option('-t, --timecodes <timecodes>', 'cut at specified timecodes (CSV: HH:MM:SS[.nnnn] or HH:MM:SS:MS,...)')
         .conflicts('segments')
         .conflicts('duration')
         .conflicts('sceneDetect')

--- a/src/core.js
+++ b/src/core.js
@@ -332,9 +332,15 @@ async function createSceneSegments (inputFile, outputDir, boundaries, verifySegm
 
 /**
  * Parse a CSV string of timecodes into an array of seconds.
- * Supported formats are HH:MM:SS[.nnnn], Ns, N.Ns, and [Nh][Nm]N[.N]s.
+ * Supported formats:
+ *   - HH:MM:SS:MS — four colon-separated parts; the final field (MS) is treated as
+ *     fractional seconds scaled by its digit count: `:4` → 0.4 s, `:04` → 0.04 s,
+ *     `:004` → 0.004 s.
+ *   - HH:MM:SS[.nnnn] — hours, minutes, seconds with an optional decimal fraction.
+ *   - Ns / N.Ns — plain seconds, e.g. "10s" or "10.25s".
+ *   - [Nh][Nm]N[.N]s — hours/minutes/seconds with letter suffixes, e.g. "1h30m15.2s".
  *
- * @param {string} timecodeString - Comma-separated timecodes, e.g. "00:00:10.000,00:00:30.000", "10s,10.25s", or "0h0m10s,1h30m15.2s"
+ * @param {string} timecodeString - Comma-separated timecodes, e.g. "00:00:10.000,00:00:30.000", "10s,10.25s", "0h0m10s,1h30m15.2s", or "00:00:24:04"
  * @returns {number[]} - Array of timestamps in seconds
  */
 function parseTimecodes (timecodeString) {

--- a/src/core.js
+++ b/src/core.js
@@ -342,8 +342,18 @@ function parseTimecodes (timecodeString) {
     const trimmed = tc.trim()
     const pos = i + 1
 
-    // Format: HH:MM:SS[.nnn]
     if (trimmed.includes(':')) {
+      // Format: HH:MM:SS:MS (four colon-separated parts, MS scaled by digit count)
+      const fourPartMatch = trimmed.match(/^(\d+):(\d+):(\d+):(\d+)$/)
+      if (fourPartMatch) {
+        const [, h, m, s, ms] = fourPartMatch
+        const msValue = Number.parseInt(ms, 10) / Math.pow(10, ms.length)
+        const seconds = Number.parseInt(h, 10) * 3600 + Number.parseInt(m, 10) * 60 + Number.parseInt(s, 10) + msValue
+        if (!Number.isFinite(seconds)) throw new Error(`Invalid timecode at position ${pos}: "${trimmed}"`)
+        return seconds
+      }
+
+      // Format: HH:MM:SS[.nnn]
       const colonMatch = trimmed.match(/^(\d+):(\d+):(\d+(?:\.\d+)?)$/)
       if (!colonMatch) throw new Error(`Invalid timecode at position ${pos}: "${trimmed}"`)
       const [, h, m, s] = colonMatch

--- a/tests/core.spec.js
+++ b/tests/core.spec.js
@@ -368,6 +368,32 @@ describe('parseTimecodes', () => {
     })
   })
 
+  describe('HH:MM:SS:MS format', () => {
+    it('parses two-digit MS as centiseconds', () => {
+      expect(parseTimecodes('00:00:24:04')).toEqual([24.04])
+    })
+
+    it('parses one-digit MS as tenths of a second', () => {
+      expect(parseTimecodes('00:00:24:4')).toEqual([24.4])
+    })
+
+    it('parses three-digit MS as milliseconds', () => {
+      expect(parseTimecodes('00:00:24:040')).toEqual([24.04])
+    })
+
+    it('parses multiple HH:MM:SS:MS timecodes', () => {
+      expect(parseTimecodes('00:00:10:00,00:00:30:50')).toEqual([10, 30.5])
+    })
+
+    it('handles hours correctly', () => {
+      expect(parseTimecodes('01:00:00:00')).toEqual([3600])
+    })
+
+    it('trims whitespace around HH:MM:SS:MS timecodes', () => {
+      expect(parseTimecodes(' 00:00:24:04 ')).toEqual([24.04])
+    })
+  })
+
   describe('Ns / N.Ns format', () => {
     it('parses whole seconds', () => {
       expect(parseTimecodes('10s,15s,25s')).toEqual([10, 15, 25])


### PR DESCRIPTION
## Summary

- Extends `parseTimecodes` in `src/core.js` to accept a four-part colon-separated timecode format (`HH:MM:SS:MS`) alongside the existing formats (`HH:MM:SS[.nnn]`, `Ns`, `NhNmNs`)
- The MS component is scaled by digit count: `:04` → 0.04s, `:4` → 0.4s, `:040` → 0.04s
- Updates the `--timecodes` CLI help text to document the new format
- Adds 6 new unit tests covering the new format

## Test plan

- [x] `parseTimecodes('00:00:24:04')` → `[24.04]`
- [x] One-digit, two-digit, and three-digit MS components all parse correctly
- [x] Multiple timecodes in the new format parse correctly
- [x] Existing formats (`HH:MM:SS[.nnn]`, `Ns`, `NhNmNs`) still pass all tests
- [x] All 100 tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)